### PR TITLE
Update postinst script to point to the absolute path

### DIFF
--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -1,3 +1,3 @@
 set -e
 ldconfig
-timesyncctl config standalone
+/usr/local/bin/timesyncctl config standalone


### PR DESCRIPTION
Issue was found during apt-get install - fixed with absolute path call